### PR TITLE
adds names to hacdat import list

### DIFF
--- a/R/Analysis_Import_EVcsv.R
+++ b/R/Analysis_Import_EVcsv.R
@@ -41,6 +41,6 @@ Analysis_Import_EVcsv <- function(){
   histo<-dplyr::bind_rows(lapply(histo, readr::read_csv))
 
   # store and return as a list
-  hacdat <- list(intg, ts, histo)
+  hacdat <- list(intg = intg, ts = ts, histo = histo)
   hacdat
 }


### PR DESCRIPTION
data imported from `Analysis_Import_EVcsv` will now return a list with named items such that tables can be called using the hacdat$intg convention